### PR TITLE
Explain in the documentation that the `cid` query parameter from Investing.com must be preserved in the ticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Click on the button below to download the latest version of the plugin directly:
     - Ticker field supports Investing.com website. You have to get the name from the url: e.g.
       - **SPDR-S-P-500** - investing.com/etfs/spdr-s-p-500
       - **ISHARES-FTSE-100** - investing.com/etfs/ishares-ftse-100
+    - _Note:_ If the Investing.com URL contains the _?cid=x_ part, ensure that you include it in the ticker field: e.g.
+      - **CS-ETF-(IE)-ON-S-P-500?CID=45844** - investing.com/etfs/cs-etf-(ie)-on-s-p-500?cid=45844
   - Forex
     - **EURUSD** - EUR/USD
     - **XAUUSD** - XAU/USD

--- a/src/inspector.html
+++ b/src/inspector.html
@@ -186,10 +186,16 @@
       &nbsp;&nbsp;&nbsp;ISHARES-FTSE-100 -
       investing.com/etfs/ishares-ftse-100<br />
     </p>
+    <p>
+      &nbsp;&nbsp;&nbsp;&nbsp;Note: If the Investing.com URL contains the "?cid=x" part, ensure that you include it in the ticker field: e.g.
+    </p>
+    <p>
+      &nbsp;&nbsp;&nbsp;CS-ETF-(IE)-ON-S-P-500?CID=45844 - investing.com/etfs/cs-etf-(ie)-on-s-p-500?cid=45844<br />
+    </p>
     <p>&nbsp;&nbsp;Forex</p>
     <p>
       &nbsp;&nbsp;&nbsp;&nbsp;&bull;EURUSD - EUR/USD <br />
-      &nbsp;&nbsp; &nbsp;&nbsp;&bull;XAUUSD - XAU/USD<br />
+      &nbsp;&nbsp;&nbsp;&nbsp;&bull;XAUUSD - XAU/USD<br />
     </p>
     <p>&nbsp;&nbsp;Commodities</p>
     <p>


### PR DESCRIPTION
This PR improves the documentation to make clear that the query param `cid` also needs to be included. 

### Let me explain:

When I visit the [Investing.com](https://investing.com/) site and search for an ETF (let's say SXR8 @ Xetra), it directs me to the following URL:

https://www.investing.com/etfs/cs-etf-(ie)-on-s-p-500?cid=45844

The CID query parameter identifies the specific ETF (in this case SXR8 @ Xetra) and returns the ETF price in EUR, which is important to me as I always buy UCITS ETFs in EUR.

However, if we visit the URL without that `cid` query parameter:

https://www.investing.com/etfs/cs-etf-(ie)-on-s-p-500

the ETF exchange defaults to a different ETF (CSPX instead of SXR8) listed on the London exchange in USD, which I am not interested in. And that's what the plugin does when a user omits the cid part (a.k.a. sets the ticker field just to `cs-etf-(ie)-on-s-p-500`, as shown in the docs) - Cheerio parses the data from the `https://www.investing.com/etfs/cs-etf-(ie)-on-s-p-500` and therefore displays the ETF price in USD. To ensure the correct/wanted exchange and currency, the ticker field needs to be set to `cs-etf-(ie)-on-s-p-500?cid=45844`. 