### PR TITLE
fix: use correct capitalisation of Keypad controller identifier

### DIFF
--- a/patches/@fnando+streamdeck+0.1.0-alpha.7.patch
+++ b/patches/@fnando+streamdeck+0.1.0-alpha.7.patch
@@ -93,7 +93,7 @@ index 6818273..114e37e 100644
 +            controllers.push("Encoder");
 +        }
 +        if (this.keyPad === true) {
-+            controllers.push("KeyPad");
++            controllers.push("Keypad");
 +        }
 +        snippet.Controllers = controllers;
          const optionals = [


### PR DESCRIPTION
Hello there @matextrem,

I see you are patching the `@fnando/streamdeck` library, with the contents of a PR to that library that adds encoder/Stream Deck Plus support.

However, the author of that PR incorrectly used "KeyPad" as the controller ID for the buttons surface, instead of "Keypad". While this doesn't cause any issues with Elgato's official software, it does prevent the action from being added to the buttons surface in [OpenDeck](https://github.com/nekename/OpenDeck) (closes #56, closes nekename/OpenDeck#230), since it seems OpenDeck matches the string more strictly.

While this would be better fixed in OpenDeck of course, I can't really be bothered to do that, so I decided to send a PR here instead :P (I doubt there are many other plugins with this issue anyway)

Thanks :)