### PR TITLE
fix: resolve issues arising from CORS restrictions on image loading

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -28,7 +28,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
       stock: {
         route: 'quote.ashx',
         query: 't',
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/ticker_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/ticker_icons',
       },
       etf: {
         route: 'etfs',
@@ -37,7 +37,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
       forex: {
         route: 'currencies',
         fallback: ApiProviders.Investing,
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/forex_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/forex_icons',
       },
       commodity: {
         route: 'commodities',
@@ -50,7 +50,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
       crypto: {
         route: 'crypto',
         fallback: ApiProviders.CoinMarketCap,
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/crypto_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/crypto_icons',
         useSiteLogo: true,
       },
       funds: {
@@ -113,14 +113,14 @@ export const API_PROVIDERS: ApiProvidersConfig = {
     endpoints: {
       stock: {
         route: 'equities',
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/ticker_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/ticker_icons',
       },
       etf: {
         route: 'etfs',
       },
       forex: {
         route: 'currencies',
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/forex_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/forex_icons',
       },
       commodity: {
         route: 'commodities',
@@ -131,7 +131,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
       crypto: {
         route: 'crypto',
         fallback: ApiProviders.CoinMarketCap,
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/crypto_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/crypto_icons',
         useSiteLogo: true,
       },
       funds: {
@@ -212,7 +212,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
         route: 'quote.ashx',
         query: 't',
         fallback: ApiProviders.Finviz,
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/ticker_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/ticker_icons',
       },
       etf: {
         route: 'etfs',
@@ -221,7 +221,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
       forex: {
         route: 'currencies',
         fallback: ApiProviders.Investing,
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/forex_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/forex_icons',
       },
       commodity: {
         route: 'commodities',
@@ -233,7 +233,7 @@ export const API_PROVIDERS: ApiProvidersConfig = {
       },
       crypto: {
         route: 'currencies',
-        iconUrl: 'https://github.com/nvstly/icons/tree/main/crypto_icons',
+        iconUrl: 'https://raw.githubusercontent.com/nvstly/icons/main/crypto_icons',
         useSiteLogo: true,
       },
     },

--- a/src/helpers/drawing.ts
+++ b/src/helpers/drawing.ts
@@ -66,7 +66,8 @@ export async function drawQuoteImage(
   const encodedSvgContent = encodeURIComponent(svgContent);
 
   const arrowImage = await loadImage(
-    `data:image/svg+xml;utf8,${encodedSvgContent}`
+    `data:image/svg+xml;utf8,${encodedSvgContent}`,
+    { crossOrigin: "anonymous" }
   );
 
   // Draw the stock ticker
@@ -84,7 +85,7 @@ export async function drawQuoteImage(
 
   if (icon) {
     // Load the icon image
-    const iconImage = await loadImage(icon);
+    const iconImage = await loadImage(icon, { crossOrigin: "anonymous" });
     const iconWidth = 24; // Set the width of the icon (adjust as needed)
     const iconHeight = 24; // Set the height of the icon (adjust as needed)
     const iconX = tickerX + tickerTextWidth + 10; // X position to draw the icon


### PR DESCRIPTION
Hello @matextrem,

Just sending a follow-up to #58 to get the plugin actually working in OpenDeck. OpenDeck doesn't have the luxury of modifying the webview to disable CORS entirely like Elgato's software does (more details [here](https://github.com/XeroxDev/Stream-Deck-TS-SDK/pull/24)), so certain internet-enabled operations fail in OpenDeck where they succeed in Elgato's software.

To fix this, I've set the images' cross-origin loading methods to `anonymous`, and used the raw.githubusercontent.com URLs (which the previous URLs redirected to anyway) to work around github.com sending different access control headers to raw.githubusercontent.com (which sends working headers).

I've only tested this by modifying the built plugin.js, and haven't actually tested the changes by making them in the source and then building, so please do check I haven't broken anything.
 
Thanks!